### PR TITLE
Add custom model configs and tokenizer support

### DIFF
--- a/config/e5_encoder_decoder.yaml
+++ b/config/e5_encoder_decoder.yaml
@@ -1,0 +1,33 @@
+# Advanced experiment using multilingual-e5-large with pretrained weights
+
+dataset:
+  train_file: "train.parquet"
+  valid_file: "valid.parquet"
+  test_file: "test.parquet"
+
+model:
+  architecture: "e5_m2m"
+  pretrained: true
+  tokenizer_name: "intfloat/multilingual-e5-large"
+
+trainer:
+  trainer_type: "seq2seq_trainer"
+  output_dir: "e5_experiment_output"
+  num_train_epochs: 1
+  per_device_train_batch_size: 8
+  per_device_eval_batch_size: 8
+  gradient_accumulation_steps: 1
+  learning_rate: 5e-5
+  weight_decay: 0.0
+  warmup_steps: 0
+  lr_scheduler_type: "cosine"
+  evaluation_strategy: "epoch"
+  save_strategy: "epoch"
+  logging_steps: 100
+  max_source_length: 128
+  max_target_length: 128
+  early_stopping_patience: 3
+  early_stopping_threshold: 0.0
+  metrics:
+    - bleu
+    - comet

--- a/config/marian_baseline.yaml
+++ b/config/marian_baseline.yaml
@@ -1,0 +1,35 @@
+# Baseline MarianMT configuration with custom tokenizers
+
+dataset:
+  train_file: "train.parquet"
+  valid_file: "valid.parquet"
+  test_file: "test.parquet"
+
+model:
+  architecture: "marian_custom"
+  encoder_name: "Helsinki-NLP/opus-mt-en-de"
+  decoder_name: "Helsinki-NLP/opus-mt-en-de"
+  encoder_tokenizer: "RichNachos/georgian-corpus-tokenizer-test"
+  decoder_tokenizer: "Helsinki-NLP/opus-mt-en-de"
+  pretrained: false
+
+trainer:
+  trainer_type: "seq2seq_trainer"
+  output_dir: "marian_baseline_output"
+  num_train_epochs: 1
+  per_device_train_batch_size: 8
+  per_device_eval_batch_size: 8
+  gradient_accumulation_steps: 1
+  learning_rate: 5e-5
+  weight_decay: 0.0
+  warmup_steps: 0
+  lr_scheduler_type: "cosine"
+  evaluation_strategy: "epoch"
+  save_strategy: "epoch"
+  logging_steps: 100
+  max_source_length: 128
+  max_target_length: 128
+  early_stopping_patience: 3
+  early_stopping_threshold: 0.0
+  metrics:
+    - bleu

--- a/config/marian_baseline.yaml
+++ b/config/marian_baseline.yaml
@@ -7,8 +7,7 @@ dataset:
 
 model:
   architecture: "marian_custom"
-  encoder_name: "Helsinki-NLP/opus-mt-en-de"
-  decoder_name: "Helsinki-NLP/opus-mt-en-de"
+  name: "Helsinki-NLP/opus-mt-en-de"
   encoder_tokenizer: "RichNachos/georgian-corpus-tokenizer-test"
   decoder_tokenizer: "Helsinki-NLP/opus-mt-en-de"
   pretrained: false

--- a/config/training.yaml
+++ b/config/training.yaml
@@ -1,0 +1,32 @@
+# Training Configuration
+
+dataset:
+  train_file: "train.parquet"
+  valid_file: "valid.parquet"
+  test_file: "test.parquet"
+
+model:
+  architecture: "auto"          # Options: auto, encoder_decoder
+  name: "Helsinki-NLP/opus-mt-en-de"  # Pretrained model name
+  pretrained: true               # Load pretrained weights or random init
+
+trainer:
+  trainer_type: "seq2seq_trainer"
+  output_dir: "model_output"
+  num_train_epochs: 1
+  per_device_train_batch_size: 8
+  per_device_eval_batch_size: 8
+  gradient_accumulation_steps: 1
+  learning_rate: 5e-5
+  weight_decay: 0.0
+  warmup_steps: 0
+  lr_scheduler_type: "cosine"
+  evaluation_strategy: "epoch"
+  save_strategy: "epoch"
+  logging_steps: 100
+  max_source_length: 128
+  max_target_length: 128
+  early_stopping_patience: 3
+  early_stopping_threshold: 0.0
+  metrics:
+    - bleu

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,9 +14,10 @@ transformers[torch]
 sentence-transformers
 pyyaml
 click
-eng
 matplotlib
 seaborn
 nltk
 requests
 wordcloud
+evaluate
+sentencepiece

--- a/src/trainer/README.md
+++ b/src/trainer/README.md
@@ -8,8 +8,8 @@ YAML file.
 
 - **Model Registry** – Register different model creation functions. Default
   options include loading any seq2seq model via the `auto` architecture,
-  a `marian_custom` option for Marian models built from scratch with custom
-  tokenizers and an `e5_m2m` encoder-decoder using multilingual-e5-large
+  a `marian_custom` option which creates a `MarianMTModel` with custom
+  tokenizers, and an `e5_m2m` encoder-decoder using multilingual-e5-large
   weights.
 - **Trainer Registry** – Swap out the training loop implementation. By default
   the pipeline uses `Seq2SeqTrainer` with an AdamW optimizer and a cosine

--- a/src/trainer/README.md
+++ b/src/trainer/README.md
@@ -1,0 +1,63 @@
+# Training Module
+
+A registry-driven training pipeline built on HuggingFace Transformers. The goal
+is to make experimenting with new models and architectures as easy as editing a
+YAML file.
+
+## Key Features
+
+- **Model Registry** – Register different model creation functions. Default
+  options include loading any seq2seq model via the `auto` architecture,
+  a `marian_custom` option for Marian models built from scratch with custom
+  tokenizers and an `e5_m2m` encoder-decoder using multilingual-e5-large
+  weights.
+- **Trainer Registry** – Swap out the training loop implementation. By default
+  the pipeline uses `Seq2SeqTrainer` with an AdamW optimizer and a cosine
+-  scheduler.
+- **Metric Registry** – Register evaluation metrics such as BLEU, chrF++
+  or COMET and reference them from the config.
+- **Early Stopping** – Built-in support via configuration options for
+  patience and threshold.
+- **YAML Configuration** – Hyperparameters, model choice and trainer settings are
+  all controlled from `config/training.yaml` and logged to Weights & Biases.
+
+## Quick Start
+
+```bash
+python -m src.trainer.runner \
+  --splits-artifact-version latest \
+  --description "Train baseline model" \
+  --config config/marian_baseline.yaml
+```
+
+The command downloads the specified `splits` artifact from WandB, creates the
+model defined in the config, trains it and logs the resulting model as a new
+artifact.
+
+For the advanced experiment using `multilingual-e5-large` run:
+
+```bash
+python -m src.trainer.runner \
+  --splits-artifact-version latest \
+  --description "Train e5 encoder-decoder" \
+  --config config/e5_encoder_decoder.yaml
+```
+
+## Adding New Architectures
+
+1. Implement a function in `src/trainer/models.py` and decorate it with
+   `@register_model("my_arch")`.
+2. Update `config/training.yaml` with `architecture: "my_arch"` and any custom
+   parameters your function expects.
+
+## Changing the Training Loop
+
+Implement a trainer creation function and register it with
+`@register_trainer("my_trainer")`. Reference it in the config under
+`trainer.trainer_type`.
+
+## Custom Metrics
+
+Metrics are defined in `src/trainer/evaluation.py` and registered with
+`@register_metric`. List the desired metrics in `trainer.metrics` within the
+config file. During validation the scores will be logged to wandb.

--- a/src/trainer/__init__.py
+++ b/src/trainer/__init__.py
@@ -1,0 +1,26 @@
+"""Training Module
+
+A configurable training pipeline for NMT experiments using HuggingFace
+Transformers. Models, tokenizers and trainers are selected via simple
+registry systems, enabling easy experimentation with different
+architectures.
+"""
+
+from .registry import (
+    model_registry,
+    trainer_registry,
+    register_model,
+    register_trainer,
+)
+from .evaluation import metric_registry, register_metric
+from .trainer import NMTTrainer
+
+__all__ = [
+    'model_registry',
+    'trainer_registry',
+    'metric_registry',
+    'register_model',
+    'register_trainer',
+    'register_metric',
+    'NMTTrainer',
+]

--- a/src/trainer/evaluation.py
+++ b/src/trainer/evaluation.py
@@ -1,0 +1,76 @@
+"""Evaluation metric registry and metric implementations."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, List
+
+import evaluate
+
+
+class MetricRegistry:
+    """A registry for mapping metric names to callable evaluation functions."""
+
+    def __init__(self) -> None:
+        self._metrics: Dict[str, Callable[[List[str], List[str]], Dict[str, float]]] = {}
+        self._descriptions: Dict[str, str] = {}
+
+    def register(self, name: str, description: str = "") -> Callable[[Callable[..., Dict[str, float]]], Callable[..., Dict[str, float]]]:
+        """Register a metric function under ``name``."""
+
+        def decorator(func: Callable[[List[str], List[str]], Dict[str, float]]) -> Callable[[List[str], List[str]], Dict[str, float]]:
+            self._metrics[name] = func
+            self._descriptions[name] = description
+            return func
+
+        return decorator
+
+    def get_metric(self, name: str) -> Callable[[List[str], List[str]], Dict[str, float]] | None:
+        """Return the metric function registered under ``name`` if present."""
+
+        return self._metrics.get(name)
+
+    def list_metrics(self) -> Dict[str, str]:
+        """Return a mapping of metric names to descriptions."""
+
+        return {name: self._descriptions.get(name, "") for name in self._metrics}
+
+
+# Global registry and decorator -------------------------------------------------
+metric_registry = MetricRegistry()
+
+
+def register_metric(name: str, description: str = "") -> Callable[[Callable[..., Dict[str, float]]], Callable[..., Dict[str, float]]]:
+    """Decorator to register a metric function with :data:`metric_registry`."""
+
+    return metric_registry.register(name, description)
+
+
+# Metric implementations -------------------------------------------------------
+
+
+@register_metric("bleu", "SacreBLEU score")
+def bleu_metric(preds: List[str], refs: List[str]) -> Dict[str, float]:
+    """Compute corpus BLEU using :mod:`evaluate`."""
+
+    metric = evaluate.load("sacrebleu")
+    result = metric.compute(predictions=preds, references=[[r] for r in refs])
+    return {"bleu": result["score"]}
+
+
+@register_metric("chrf", "chrF++ score")
+def chrf_metric(preds: List[str], refs: List[str]) -> Dict[str, float]:
+    """Compute chrF++ using :mod:`evaluate`."""
+
+    metric = evaluate.load("chrf")
+    result = metric.compute(predictions=preds, references=refs)
+    return {"chrf": result["score"]}
+
+
+@register_metric("comet", "COMET model evaluation")
+def comet_metric(preds: List[str], refs: List[str]) -> Dict[str, float]:
+    """Compute COMET score using a pretrained or fine-tuned COMET model."""
+
+    metric = evaluate.load("comet", model_id="Darsala/georgian_comet")
+    result = metric.compute(predictions=preds, references=refs, sources=None)
+    return {"comet": result["score"]}
+

--- a/src/trainer/models.py
+++ b/src/trainer/models.py
@@ -1,0 +1,144 @@
+"""Model creation functions registered for the training pipeline."""
+
+from typing import Any, Dict, Tuple
+from pathlib import Path
+
+from transformers import (
+    AutoConfig,
+    AutoModel,
+    AutoModelForCausalLM,
+    AutoModelForSeq2SeqLM,
+    AutoTokenizer,
+    EncoderDecoderModel,
+    MarianConfig,
+    MarianModel,
+)
+
+from .registry import register_model
+
+
+@register_model("auto", "Load a standard seq2seq model via Auto classes")
+def load_auto_model(config: Dict[str, Any]) -> Tuple[AutoModelForSeq2SeqLM, AutoTokenizer]:
+    """Load a Seq2Seq model and tokenizer based on a single model name."""
+    model_name = config.get("name")
+    pretrained = config.get("pretrained", True)
+    if pretrained:
+        model = AutoModelForSeq2SeqLM.from_pretrained(model_name)
+    else:
+        model_cfg = AutoConfig.from_pretrained(model_name)
+        model = AutoModelForSeq2SeqLM.from_config(model_cfg)
+    tokenizer_name = config.get("tokenizer_name", model_name)
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
+    return model, tokenizer
+
+
+@register_model("encoder_decoder", "Combine separate encoder and decoder models")
+def load_encoder_decoder_model(config: Dict[str, Any]) -> Tuple[EncoderDecoderModel, AutoTokenizer]:
+    """Create an EncoderDecoderModel from separate encoder and decoder."""
+    encoder_name = config.get("encoder_name")
+    decoder_name = config.get("decoder_name")
+    pretrained = config.get("pretrained", True)
+
+    if pretrained:
+        encoder = AutoModel.from_pretrained(encoder_name)
+        decoder = AutoModelForCausalLM.from_pretrained(decoder_name)
+    else:
+        encoder_cfg = AutoConfig.from_pretrained(encoder_name)
+        decoder_cfg = AutoConfig.from_pretrained(decoder_name)
+        encoder = AutoModel.from_config(encoder_cfg)
+        decoder = AutoModelForCausalLM.from_config(decoder_cfg)
+
+    model = EncoderDecoderModel(encoder=encoder, decoder=decoder)
+
+    tokenizer_name = config.get("tokenizer_name", encoder_name)
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
+
+    if model.config.decoder_start_token_id is None:
+        model.config.decoder_start_token_id = tokenizer.cls_token_id
+    if model.config.pad_token_id is None:
+        model.config.pad_token_id = tokenizer.pad_token_id
+
+    return model, tokenizer
+
+
+class DualTokenizer:
+    """Wrapper combining separate encoder and decoder tokenizers."""
+
+    def __init__(self, encoder_tokenizer: Any, decoder_tokenizer: Any) -> None:
+        self.encoder_tokenizer = encoder_tokenizer
+        self.decoder_tokenizer = decoder_tokenizer
+
+    def __getattr__(self, item: str) -> Any:
+        return getattr(self.encoder_tokenizer, item)
+
+    def as_target_tokenizer(self) -> Any:
+        return self.decoder_tokenizer
+
+    def batch_decode(self, *args: Any, **kwargs: Any) -> Any:
+        return self.decoder_tokenizer.batch_decode(*args, **kwargs)
+
+    def save_pretrained(self, save_directory: str) -> None:
+        self.encoder_tokenizer.save_pretrained(Path(save_directory) / "encoder")
+        self.decoder_tokenizer.save_pretrained(Path(save_directory) / "decoder")
+
+
+@register_model(
+    "marian_custom",
+    "Marian encoder-decoder from scratch with separate tokenizers",
+)
+def load_marian_custom_model(config: Dict[str, Any]) -> Tuple[EncoderDecoderModel, DualTokenizer]:
+    """Create a Marian encoder-decoder model initialized from scratch."""
+
+    encoder_name = config.get("encoder_name", "Helsinki-NLP/opus-mt-en-de")
+    decoder_name = config.get("decoder_name", "Helsinki-NLP/opus-mt-en-de")
+    enc_tokenizer_name = config.get("encoder_tokenizer")
+    dec_tokenizer_name = config.get("decoder_tokenizer")
+
+    enc_tokenizer = AutoTokenizer.from_pretrained(enc_tokenizer_name)
+    dec_tokenizer = AutoTokenizer.from_pretrained(dec_tokenizer_name)
+    tokenizer = DualTokenizer(enc_tokenizer, dec_tokenizer)
+
+    encoder_cfg = MarianConfig.from_pretrained(encoder_name)
+    decoder_cfg = MarianConfig.from_pretrained(decoder_name)
+    decoder_cfg.is_decoder = True
+    decoder_cfg.add_cross_attention = True
+
+    encoder = MarianModel(encoder_cfg)
+    decoder = MarianModel(decoder_cfg)
+
+    model = EncoderDecoderModel(encoder=encoder, decoder=decoder)
+
+    if model.config.decoder_start_token_id is None:
+        model.config.decoder_start_token_id = dec_tokenizer.cls_token_id
+    if model.config.pad_token_id is None:
+        model.config.pad_token_id = dec_tokenizer.pad_token_id
+
+    return model, tokenizer
+
+
+@register_model(
+    "e5_m2m",
+    "Encoder-decoder using multilingual-e5-large weights",
+)
+def load_e5_encoder_decoder(config: Dict[str, Any]) -> Tuple[EncoderDecoderModel, AutoTokenizer]:
+    """Create an encoder-decoder model using multilingual-e5-large for both sides."""
+
+    model_name = "intfloat/multilingual-e5-large"
+    tokenizer_name = config.get("tokenizer_name", model_name)
+
+    encoder = AutoModel.from_pretrained(model_name)
+    decoder_cfg = AutoConfig.from_pretrained(model_name)
+    decoder_cfg.is_decoder = True
+    decoder_cfg.add_cross_attention = True
+    decoder = AutoModelForCausalLM.from_config(decoder_cfg)
+
+    model = EncoderDecoderModel(encoder=encoder, decoder=decoder)
+
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
+
+    if model.config.decoder_start_token_id is None:
+        model.config.decoder_start_token_id = tokenizer.cls_token_id
+    if model.config.pad_token_id is None:
+        model.config.pad_token_id = tokenizer.pad_token_id
+
+    return model, tokenizer

--- a/src/trainer/registry.py
+++ b/src/trainer/registry.py
@@ -1,0 +1,81 @@
+"""Registries for models and trainers."""
+
+from typing import Callable, Dict, Optional
+
+
+class ModelRegistry:
+    """Registry mapping model names to factory functions."""
+
+    def __init__(self) -> None:
+        """Initialize an empty registry."""
+
+        self._models: Dict[str, Callable] = {}
+        self._descriptions: Dict[str, str] = {}
+
+    def register(self, name: str, description: str = "") -> Callable:
+        """Return a decorator registering ``func`` under ``name``."""
+
+        def decorator(func: Callable) -> Callable:
+            self._models[name] = func
+            self._descriptions[name] = description
+            return func
+
+        return decorator
+
+    def get_model(self, name: str) -> Optional[Callable]:
+        """Return the model factory registered as ``name`` if it exists."""
+
+        return self._models.get(name)
+
+    def list_models(self) -> Dict[str, str]:
+        """Return a mapping of registered model names to descriptions."""
+
+        return {name: self._descriptions.get(name, "") for name in self._models}
+
+
+class TrainerRegistry:
+    """Registry mapping trainer names to factory functions."""
+
+    def __init__(self) -> None:
+        """Initialize an empty trainer registry."""
+
+        self._trainers: Dict[str, Callable] = {}
+        self._descriptions: Dict[str, str] = {}
+
+    def register(self, name: str, description: str = "") -> Callable:
+        """Return a decorator registering ``func`` under ``name``."""
+
+        def decorator(func: Callable) -> Callable:
+            self._trainers[name] = func
+            self._descriptions[name] = description
+            return func
+
+        return decorator
+
+    def get_trainer(self, name: str) -> Optional[Callable]:
+        """Return the trainer factory registered as ``name`` if it exists."""
+
+        return self._trainers.get(name)
+
+    def list_trainers(self) -> Dict[str, str]:
+        """Return a mapping of registered trainer names to descriptions."""
+
+        return {name: self._descriptions.get(name, "") for name in self._trainers}
+
+
+# Global registries
+model_registry = ModelRegistry()
+trainer_registry = TrainerRegistry()
+
+
+# Convenience decorators
+def register_model(name: str, description: str = "") -> Callable:
+    """Decorator to register a model factory in :data:`model_registry`."""
+
+    return model_registry.register(name, description)
+
+
+def register_trainer(name: str, description: str = "") -> Callable:
+    """Decorator to register a trainer factory in :data:`trainer_registry`."""
+
+    return trainer_registry.register(name, description)

--- a/src/trainer/runner.py
+++ b/src/trainer/runner.py
@@ -1,0 +1,131 @@
+"""Command line interface for launching training experiments."""
+
+import os
+from pathlib import Path
+import click
+import wandb
+
+from src.trainer import NMTTrainer
+from src.utils.utils import generate_folder_name, get_s3_loader
+
+
+@click.command()
+@click.option(
+    "--splits-artifact-version",
+    required=True,
+    type=str,
+    help="Version of the splits dataset artifact to use for training",
+)
+@click.option(
+    "--bucket",
+    default="personal-data-science-data",
+    required=False,
+    type=str,
+    help="S3 bucket name where trained model will be saved",
+)
+@click.option(
+    "--project",
+    default="NMT_Training",
+    required=False,
+    type=str,
+    help="WandB project name to log to",
+)
+@click.option(
+    "--description",
+    required=True,
+    type=str,
+    help="Description of this training run",
+)
+@click.option(
+    "--config",
+    default="config/training.yaml",
+    required=False,
+    type=str,
+    help="Path to training configuration file",
+)
+@click.option(
+    "--develop",
+    is_flag=True,
+    default=False,
+    help="Run in development mode without logging to personal account",
+)
+
+def main(
+    splits_artifact_version: str,
+    bucket: str,
+    project: str,
+    description: str,
+    config: str,
+    develop: bool,
+) -> None:
+    """Run a training experiment based on configuration and dataset version.
+
+    Parameters
+    ----------
+    splits_artifact_version:
+        Version of the dataset splits artifact to download from Weights & Biases.
+    bucket:
+        Name of the S3 bucket to upload the final model to.
+    project:
+        WandB project name used for logging.
+    description:
+        Short description for this training run.
+    config:
+        Path to the YAML configuration file.
+    develop:
+        If ``True``, run in anonymous mode without using a personal account.
+    """
+
+    if develop:
+        os.environ.pop("WANDB_API_KEY", None)
+
+    for arg, value in locals().items():
+        print(f"{arg}: {value}")
+
+    with wandb.init(
+        project=project,
+        job_type="train-model",
+        tags=["pipeline", "training"],
+        notes=description,
+        save_code=True,
+        anonymous="must" if develop else "allow",
+    ) as run:
+        print(f"Downloading splits artifact: splits:{splits_artifact_version}")
+        splits_artifact = run.use_artifact(f"splits:{splits_artifact_version}")
+        data_dir = splits_artifact.download()
+        print(f"Downloaded splits to: {data_dir}")
+
+        artifact = wandb.Artifact(
+            name="model",
+            type="model",
+            description=description,
+        )
+
+        output_folder_dir = Path("artifacts") / "models" / generate_folder_name()
+        output_folder_dir.mkdir(parents=True, exist_ok=True)
+        artifact.metadata.update({"output_dir": str(output_folder_dir)})
+
+        s3_loader = get_s3_loader(bucket)
+
+        trainer = NMTTrainer(
+            artifact=artifact,
+            dataset_dir=str(data_dir),
+            config_path=config,
+        )
+
+        trainer.run_training()
+
+        print(f"\nUploading model to S3: s3://{bucket}/{output_folder_dir}")
+        s3_loader.upload(trainer.config.get("trainer", {}).get("output_dir", "model_output"))
+
+        artifact.add_reference(f"s3://{bucket}/{str(output_folder_dir)}")
+        run.log_artifact(artifact)
+
+        print("\n✅ Training pipeline completed successfully!")
+        print(f"   Source artifact: splits:{splits_artifact_version}")
+        print(f"   Model saved to: {trainer.config.get('trainer', {}).get('output_dir', 'model_output')}")
+        print(f"   S3 location: s3://{bucket}/{output_folder_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/trainer/trainer.py
+++ b/src/trainer/trainer.py
@@ -1,6 +1,7 @@
 """NMT training pipeline with registry-based extensibility."""
 
 import os
+import inspect
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
@@ -142,21 +143,26 @@ class NMTTrainer:
         output_dir = cfg.get("output_dir", "model_output")
         os.makedirs(output_dir, exist_ok=True)
 
-        training_args = TrainingArguments(
-            output_dir=output_dir,
-            num_train_epochs=cfg.get("num_train_epochs", 3),
-            per_device_train_batch_size=cfg.get("per_device_train_batch_size", 8),
-            per_device_eval_batch_size=cfg.get("per_device_eval_batch_size", 8),
-            gradient_accumulation_steps=cfg.get("gradient_accumulation_steps", 1),
-            learning_rate=cfg.get("learning_rate", 5e-5),
-            weight_decay=cfg.get("weight_decay", 0.0),
-            warmup_steps=cfg.get("warmup_steps", 0),
-            lr_scheduler_type=cfg.get("lr_scheduler_type", "cosine"),
-            evaluation_strategy=cfg.get("evaluation_strategy", "epoch"),
-            save_strategy=cfg.get("save_strategy", "epoch"),
-            logging_steps=cfg.get("logging_steps", 100),
-            report_to="wandb",
-        )
+        arg_values = {
+            "output_dir": output_dir,
+            "num_train_epochs": cfg.get("num_train_epochs", 3),
+            "per_device_train_batch_size": cfg.get("per_device_train_batch_size", 8),
+            "per_device_eval_batch_size": cfg.get("per_device_eval_batch_size", 8),
+            "gradient_accumulation_steps": cfg.get("gradient_accumulation_steps", 1),
+            "learning_rate": cfg.get("learning_rate", 5e-5),
+            "weight_decay": cfg.get("weight_decay", 0.0),
+            "warmup_steps": cfg.get("warmup_steps", 0),
+            "lr_scheduler_type": cfg.get("lr_scheduler_type", "cosine"),
+            "evaluation_strategy": cfg.get("evaluation_strategy", "epoch"),
+            "save_strategy": cfg.get("save_strategy", "epoch"),
+            "logging_steps": cfg.get("logging_steps", 100),
+            "report_to": "wandb",
+        }
+
+        valid_args = inspect.signature(TrainingArguments.__init__).parameters
+        filtered_args = {k: v for k, v in arg_values.items() if k in valid_args}
+
+        training_args = TrainingArguments(**filtered_args)
 
         metrics = cfg.get("metrics", [])
 

--- a/src/trainer/trainer.py
+++ b/src/trainer/trainer.py
@@ -1,0 +1,228 @@
+"""NMT training pipeline with registry-based extensibility."""
+
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import wandb
+import yaml
+from datasets import load_dataset
+from transformers import (
+    DataCollatorForSeq2Seq,
+    EarlyStoppingCallback,
+    Seq2SeqTrainer,
+    TrainingArguments,
+)
+
+from .models import *  # register model functions
+from .registry import model_registry, trainer_registry
+from .evaluation import metric_registry
+
+
+@trainer_registry.register("seq2seq_trainer", "HuggingFace Seq2SeqTrainer")
+def default_trainer(
+    model: Any,
+    tokenizer: Any,
+    train_dataset: Any,
+    eval_dataset: Any,
+    training_args: TrainingArguments,
+) -> Seq2SeqTrainer:
+    """Create a standard :class:`~transformers.Seq2SeqTrainer`."""
+
+    data_collator = DataCollatorForSeq2Seq(tokenizer, model=model)
+    trainer = Seq2SeqTrainer(
+        model=model,
+        args=training_args,
+        train_dataset=train_dataset,
+        eval_dataset=eval_dataset,
+        tokenizer=tokenizer,
+        data_collator=data_collator,
+    )
+    return trainer
+
+
+class NMTTrainer:
+    """Main interface for running training experiments."""
+
+    def __init__(self, artifact: wandb.Artifact, dataset_dir: str, config_path: str = "config/training.yaml") -> None:
+        """Initialize the trainer with an artifact, dataset location and config file."""
+
+        self.artifact = artifact
+        self.dataset_dir = Path(dataset_dir)
+        self.config_path = Path(config_path)
+        self.config = self._load_config()
+        self._log_config_to_wandb()
+
+    def _load_config(self) -> Dict[str, Any]:
+        """Load YAML configuration from :attr:`config_path`."""
+
+        if not self.config_path.exists():
+            raise FileNotFoundError(f"Config file not found: {self.config_path}")
+        with open(self.config_path, "r", encoding="utf-8") as f:
+            return yaml.safe_load(f)
+
+    def _log_config_to_wandb(self) -> None:
+        """Attach configuration and source files to the wandb artifact."""
+
+        self.artifact.add_file(str(self.config_path), name="training_config.yaml")
+        code_files = [
+            "src/trainer/trainer.py",
+            "src/trainer/models.py",
+            "src/trainer/registry.py",
+            "src/trainer/evaluation.py",
+        ]
+        for file_path in code_files:
+            if Path(file_path).exists():
+                self.artifact.add_file(file_path, name=f"training_code/{Path(file_path).name}")
+
+    # ------------------------------------------------------------------
+    def _load_datasets(self) -> Tuple[Any, Any, Any]:
+        """Load train, validation and test datasets from parquet files."""
+
+        ds_cfg = self.config.get("dataset", {})
+        train_file = self.dataset_dir / ds_cfg.get("train_file", "train.parquet")
+        valid_file = self.dataset_dir / ds_cfg.get("valid_file", "valid.parquet")
+        test_file = self.dataset_dir / ds_cfg.get("test_file", "test.parquet")
+
+        dataset = load_dataset(
+            "parquet",
+            data_files={
+                "train": str(train_file),
+                "validation": str(valid_file),
+                "test": str(test_file),
+            },
+        )
+        return dataset["train"], dataset["validation"], dataset["test"]
+
+    def _build_model(self) -> Tuple[Any, Any]:
+        """Create model and tokenizer based on the configured architecture."""
+
+        model_cfg = self.config.get("model", {})
+        architecture = model_cfg.get("architecture", "auto")
+        model_fn = model_registry.get_model(architecture)
+        if model_fn is None:
+            raise ValueError(
+                f"Model architecture '{architecture}' not found. Available: {list(model_registry.list_models().keys())}"
+            )
+        return model_fn(model_cfg)
+
+    def _tokenize_dataset(self, tokenizer: Any, train_ds: Any, valid_ds: Any, test_ds: Any) -> Tuple[Any, Any, Any]:
+        """Tokenize raw datasets using the provided tokenizer."""
+
+        cfg = self.config.get("trainer", {})
+        src_len = cfg.get("max_source_length", 128)
+        tgt_len = cfg.get("max_target_length", 128)
+
+        enc_tok = getattr(tokenizer, "encoder_tokenizer", tokenizer)
+        dec_tok = getattr(tokenizer, "decoder_tokenizer", tokenizer)
+
+        def preprocess(examples):
+            model_inputs = enc_tok(
+                examples["en"],
+                max_length=src_len,
+                truncation=True,
+            )
+            labels = dec_tok(
+                examples["ka"],
+                max_length=tgt_len,
+                truncation=True,
+            )
+            model_inputs["labels"] = labels["input_ids"]
+            return model_inputs
+
+        train_ds = train_ds.map(preprocess, batched=True)
+        valid_ds = valid_ds.map(preprocess, batched=True)
+        test_ds = test_ds.map(preprocess, batched=True)
+        return train_ds, valid_ds, test_ds
+
+    def _build_trainer(self, model: Any, tokenizer: Any, train_ds: Any, valid_ds: Any, test_ds: Any) -> Tuple[Seq2SeqTrainer, str]:
+        """Instantiate the trainer and attach callbacks/metrics."""
+
+        cfg = self.config.get("trainer", {})
+        output_dir = cfg.get("output_dir", "model_output")
+        os.makedirs(output_dir, exist_ok=True)
+
+        training_args = TrainingArguments(
+            output_dir=output_dir,
+            num_train_epochs=cfg.get("num_train_epochs", 3),
+            per_device_train_batch_size=cfg.get("per_device_train_batch_size", 8),
+            per_device_eval_batch_size=cfg.get("per_device_eval_batch_size", 8),
+            gradient_accumulation_steps=cfg.get("gradient_accumulation_steps", 1),
+            learning_rate=cfg.get("learning_rate", 5e-5),
+            weight_decay=cfg.get("weight_decay", 0.0),
+            warmup_steps=cfg.get("warmup_steps", 0),
+            lr_scheduler_type=cfg.get("lr_scheduler_type", "cosine"),
+            evaluation_strategy=cfg.get("evaluation_strategy", "epoch"),
+            save_strategy=cfg.get("save_strategy", "epoch"),
+            logging_steps=cfg.get("logging_steps", 100),
+            report_to="wandb",
+        )
+
+        metrics = cfg.get("metrics", [])
+
+        def compute_metrics(eval_preds: Tuple[Any, Any]) -> Dict[str, float]:
+            preds, labels = eval_preds
+            if isinstance(preds, tuple):
+                preds = preds[0]
+            decoded_preds = tokenizer.batch_decode(preds, skip_special_tokens=True)
+            decoded_labels = tokenizer.batch_decode(labels, skip_special_tokens=True)
+            decoded_preds = [p.strip() for p in decoded_preds]
+            decoded_labels = [l.strip() for l in decoded_labels]
+
+            all_scores: Dict[str, float] = {}
+            for name in metrics:
+                metric_fn = metric_registry.get_metric(name)
+                if metric_fn is None:
+                    raise ValueError(
+                        f"Metric '{name}' not found. Available: {list(metric_registry.list_metrics().keys())}"
+                    )
+                all_scores.update(metric_fn(decoded_preds, decoded_labels))
+            return all_scores
+
+        trainer_type = cfg.get("trainer_type", "seq2seq_trainer")
+        trainer_fn = trainer_registry.get_trainer(trainer_type)
+        if trainer_fn is None:
+            raise ValueError(
+                f"Trainer '{trainer_type}' not found. Available: {list(trainer_registry.list_trainers().keys())}"
+            )
+        trainer = trainer_fn(
+            model,
+            tokenizer,
+            train_ds,
+            valid_ds,
+            training_args,
+        )
+
+        if metrics:
+            trainer.compute_metrics = compute_metrics
+
+        patience = cfg.get("early_stopping_patience")
+        if patience and patience > 0:
+            threshold = cfg.get("early_stopping_threshold", 0.0)
+            trainer.add_callback(
+                EarlyStoppingCallback(
+                    early_stopping_patience=patience,
+                    early_stopping_threshold=threshold,
+                )
+            )
+
+        return trainer, output_dir
+
+    # ------------------------------------------------------------------
+    def run_training(self) -> None:
+        """Execute the full training loop."""
+
+        train_ds, valid_ds, test_ds = self._load_datasets()
+        model, tokenizer = self._build_model()
+        train_ds, valid_ds, test_ds = self._tokenize_dataset(tokenizer, train_ds, valid_ds, test_ds)
+        trainer, output_dir = self._build_trainer(model, tokenizer, train_ds, valid_ds, test_ds)
+        trainer.train()
+        trainer.save_model(output_dir)
+        tokenizer.save_pretrained(output_dir)
+        self.artifact.add_dir(output_dir)
+        self.artifact.metadata.update({
+            "num_train_samples": len(train_ds),
+            "num_valid_samples": len(valid_ds),
+            "num_test_samples": len(test_ds),
+        })
+        print(f"Model saved to {output_dir}")

--- a/src/trainer/trainer.py
+++ b/src/trainer/trainer.py
@@ -12,7 +12,7 @@ from transformers import (
     DataCollatorForSeq2Seq,
     EarlyStoppingCallback,
     Seq2SeqTrainer,
-    TrainingArguments,
+    Seq2SeqTrainingArguments,
 )
 
 from .models import *  # register model functions
@@ -26,7 +26,7 @@ def default_trainer(
     tokenizer: Any,
     train_dataset: Any,
     eval_dataset: Any,
-    training_args: TrainingArguments,
+    training_args: Seq2SeqTrainingArguments,
 ) -> Seq2SeqTrainer:
     """Create a standard :class:`~transformers.Seq2SeqTrainer`."""
 
@@ -159,10 +159,10 @@ class NMTTrainer:
             "report_to": "wandb",
         }
 
-        valid_args = inspect.signature(TrainingArguments.__init__).parameters
+        valid_args = inspect.signature(Seq2SeqTrainingArguments.__init__).parameters
         filtered_args = {k: v for k, v in arg_values.items() if k in valid_args}
 
-        training_args = TrainingArguments(**filtered_args)
+        training_args = Seq2SeqTrainingArguments(**filtered_args)
 
         metrics = cfg.get("metrics", [])
 


### PR DESCRIPTION
## Summary
- add Marian baseline and multilingual-e5 configs
- support dual tokenizers and new model types in `models.py`
- update training pipeline to use dual tokenizers when provided
- document new experiments in README
- tidy requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684c2e3949688332a6790371df9655e3